### PR TITLE
feat(release): prepare v2.1.0 (config autoload, precedence docs, tests)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -45,14 +45,15 @@ const packageJson = JSON.parse(
 function tryLoadLocalConfig(configRelPath = DEFAULT_CONFIG_FILE) {
   try {
     const abs = path.resolve(process.cwd(), configRelPath);
-    if (!fs.existsSync(abs)) return undefined;
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    if (!fs.existsSync(abs)) return;
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     const raw = fs.readFileSync(abs, 'utf8');
     const parsed = JSON.parse(raw);
     return validateConfigObject(parsed);
   } catch {
     // Swallow and treat as no config; actual loading with --config will surface errors
-    return undefined;
+    return;
   }
 }
 
@@ -93,14 +94,8 @@ program
 program
   .command('i18n-to-excel')
   .description('Convert i18n JSON files to Excel')
-  .option(
-    '-i, --input <path>',
-    'path to directory containing i18n JSON files',
-  )
-  .option(
-    '-o, --output <file>',
-    'path for the output Excel file',
-  )
+  .option('-i, --input <path>', 'path to directory containing i18n JSON files')
+  .option('-o, --output <file>', 'path for the output Excel file')
   .option('-s, --sheet-name <name>', DESC_SHEET_NAME)
   .option('-d, --dry-run', DESC_DRY_RUN)
   .option('--no-report', DESC_NO_REPORT)
@@ -108,7 +103,12 @@ program
   .action((options) => {
     displayHeader();
     options.i18nToExcel = true;
-    processCliOptions(options, defaultConfig, LOCAL_CONFIG || {}, validateConfigObject);
+    processCliOptions(
+      options,
+      defaultConfig,
+      LOCAL_CONFIG || {},
+      validateConfigObject,
+    );
   });
 
 // Command for Excel to i18n
@@ -124,7 +124,12 @@ program
   .action((options) => {
     displayHeader();
     options.excelToI18n = true;
-    processCliOptions(options, defaultConfig, LOCAL_CONFIG || {}, validateConfigObject);
+    processCliOptions(
+      options,
+      defaultConfig,
+      LOCAL_CONFIG || {},
+      validateConfigObject,
+    );
   });
 
 // Command for initializing i18n directory and files
@@ -138,7 +143,12 @@ program
   .action((options) => {
     displayHeader();
     options.init = true;
-    processCliOptions(options, defaultConfig, LOCAL_CONFIG || {}, validateConfigObject);
+    processCliOptions(
+      options,
+      defaultConfig,
+      LOCAL_CONFIG || {},
+      validateConfigObject,
+    );
   });
 
 /**

--- a/test/cli.config.autoload.test.js
+++ b/test/cli.config.autoload.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { describe, it } from 'node:test';
-import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -11,11 +11,15 @@ const projectRoot = path.resolve(__dirname, '..');
 
 function runCliIn(cwd, args) {
   return new Promise((resolve) => {
-    const proc = spawn(process.execPath, [path.resolve(projectRoot, 'cli.js'), ...args], {
-      cwd,
-      env: { ...process.env, FORCE_COLOR: '0', CI: '1' },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    const proc = spawn(
+      process.execPath,
+      [path.resolve(projectRoot, 'cli.js'), ...args],
+      {
+        cwd,
+        env: { ...process.env, FORCE_COLOR: '0', CI: '1' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
     let out = '';
     let err = '';
     proc.stdout.on('data', (d) => (out += String(d)));
@@ -48,15 +52,27 @@ describe('CLI config autoload from CWD', () => {
           sheetName: 'Translations',
         },
       };
-      await fs.writeFile(path.join(tmp, 'config.json'), JSON.stringify(cfg), 'utf8');
+      await fs.writeFile(
+        path.join(tmp, 'config.json'),
+        JSON.stringify(cfg),
+        'utf8',
+      );
 
       // And create minimal i18n source files
       const localesDir = path.join(tmp, 'locales');
       await fs.mkdir(localesDir, { recursive: true });
-      await fs.writeFile(path.join(localesDir, 'en.json'), JSON.stringify({ hello: 'Hello' }), 'utf8');
+      await fs.writeFile(
+        path.join(localesDir, 'en.json'),
+        JSON.stringify({ hello: 'Hello' }),
+        'utf8',
+      );
 
       // Act: run CLI without -i/-o, only dry-run
-      const res = await runCliIn(tmp, ['i18n-to-excel', '--dry-run', '--no-report']);
+      const res = await runCliIn(tmp, [
+        'i18n-to-excel',
+        '--dry-run',
+        '--no-report',
+      ]);
 
       // Assert
       assert.equal(res.code, 0, res.err || res.out);


### PR DESCRIPTION
This PR prepares the 2.1.0 release:
- Fix: Autoload ./config.json from CWD for defaults (config optional but respected)
- Respect precedence: CLI > config.defaults > built-ins; languageMap: CLI > config.languages > runtime
- Add tests covering autoload, custom --config path, CLI override precedence, and params branches
- Docs: Update README Configuration section minimally to describe config autoload, precedence, and examples
- Bump version to 2.1.0

All checks are green locally: lint, format, tests, and coverage (branches > 90%).